### PR TITLE
Added script for creature 6066 (Earthgrab Totem)

### DIFF
--- a/acid_classic.sql
+++ b/acid_classic.sql
@@ -21229,6 +21229,8 @@ INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_invers
 INSERT INTO `creature_ai_scripts` (`id`,`creature_id`,`event_type`,`event_inverse_phase_mask`,`event_chance`,`event_flags`,`event_param1`,`event_param2`,`event_param3`,`event_param4`,`action1_type`,`action1_param1`,`action1_param2`,`action1_param3`,`action2_type`,`action2_param1`,`action2_param2`,`action2_param3`,`action3_type`,`action3_param1`,`action3_param2`,`action3_param3`,`comment`) VALUES
 -- Archery Target
 ('520201','5202','11','0','100','0','0','0','0','0','21','0','0','0','0','0','0','0','0','0','0','0','Archery Target - Prevent Combat Movement on Spawn'),
+-- Earthgrab Totem
+('606601','6066','11','0','100','0','0','0','0','0','21','0','0','0','20','0','0','0','11','8378','0','1','Earthgrab totem - Prevent Combat Movement and Prevent Melee and cast earthgrab on Spawn'),
 -- Enraged Wyvern
 ('929701','9297','11','0','100','0','0','0','0','0','11','7276','0','1','0','0','0','0','0','0','0','0','Enraged Wyvern - Cast Poison Proc on Spawn'),
 -- Enraged Gryphon


### PR DESCRIPTION
Workaround because creature 6066 (Earthgrab Totem) is summoned by spell
8376 which has wrong spell effect 42 (SPELL_EFFECT_SUMMON_GUARDIAN)
instead of spell effect 87 (SPELL_EFFECT_SUMMON_TOTEM_SLOT1) preventing
the summoned creature to properly use the TotemAI. Hence, we have to
emulate the right AI with ACID (eventAI)
